### PR TITLE
Add ability to pass map functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,18 @@ The options object takes the following parameters:
     password: "password",
     database: "bigdata"
   },
-  removeOlderThan: "5"
+  removeOlderThan: "5",
+  process_row: function(row) {
+    row.foo = 'bar';
+    return row;
+  }
 }
 ```
 
-All options are required except for `removeOlderThan`.
+All options are required except for `removeOlderThan` and `process_row`.
 
 `removeOlderThan` will allow Albedo to remove any reports matching the same name that are older than the specified number of days. By default, it will not remove any reports if this value is not specified.
+`process_row` can be either a function or an array of functions, which will be used to modify data after it comes back from the database. For example, you may want to use it to separate JSON fields into two separate columns in the CSV output. Each function takes in a row as input, and must return the modified row.
 
 The `report` object in the  callback will return a report object if successful, which contains the following information:
 

--- a/albedo.js
+++ b/albedo.js
@@ -12,105 +12,93 @@ module.exports = {
    */
   processReport: function(options, callback) {
 
-    var err;
-
-    if(options) {
-
-      if(options.connection.type === "mysql") {
-
-        var connection = mysql.createConnection({
-        host: options.connection.host,
-        user: options.connection.user,
-        password: options.connection.password,
-        database: options.connection.database,
-        insecureAuth: true
-        });
-
-        connection.query(options.query, function (err, rows, fields) {
-
-        if (err) {
-
-            callback(err);
-        } else if (rows.length > 0) {
-
-            var fields = Object.keys(rows[0]);
-
-            json2csv({
-                data: rows,
-                fields: fields
-              }, function (err, csv) {
-
-                if (err) {
-                    callback(err);
-                } else {
-                  //remove old reports if there are ones
-                  if(options.removeOlderThan) {
-                    rmDir = function(dirPath) {
-                      try { var files = fs.readdirSync(dirPath); }
-                      catch(e) { callback(e); }
-                    
-                      if (files.length > 0) {
-                        for (var i = 0; i < files.length; i++) {
-                          var filePath = dirPath + '/' + files[i];
-                          var fileName = files[i];
-                          if (fs.statSync(filePath).isFile()) {
-                            var now = moment().unix();
-                            var daysAgo = now - (parseInt(options.removeOlderThan) * 86400);
-                            var fileTime = moment(fs.statSync(filePath).mtime).unix();
-                            if(fileName.substring(0, options.name.length) == options.name) {
-                              if (fileTime  < daysAgo)
-                              {
-                                fs.unlinkSync(filePath);
-                                console.log("deleted: " + filePath);
-                              }
-                              else{
-                                console.log("kept: " + filePath);
-                              }
-                            }
-                          }
-                        else {
-                          rmDir(filePath);
-                        }
-                      }
-                    }
-                  };
- 
-                rmDir(options.location);
-              }
-              //make the new report
-              var fileName =  options.name + "_" + moment().format("YYYY-MM-DD_HH-mm-ss") + '.csv';
-              fs.writeFile(options.location + "/" + fileName, csv, function (err) {
-                if (err) {
-                  callback(err);
-                } else {
-                  var reportInfo = {
-                    name: fileName,
-                    path: options.location + '/'
-                  }; 
-
-                  callback(null, reportInfo);
-                }
-              });
-            }
-          });
-        } else {
-          callback('No records for query');
-        }
-      });
-
-      connection.end();
-
-      }
-
-      else {
-        err = 'The selected database type is not yet supported';
-        callback(err);
-      }
+    if (!options) {
+      return callback('processReport requires options, see documentation');
     }
 
-    else {
-      err = 'processReport requires options, see documentation';
-      callback(err);
+    if (options.connection.type != "mysql") {
+      return callback('The selected database type is not yet supported');
+    }
+
+    var connection = mysql.createConnection({
+      host: options.connection.host,
+      user: options.connection.user,
+      password: options.connection.password,
+      database: options.connection.database,
+      insecureAuth: true
+    });
+
+    connection.query(options.query, function (err, rows, fields) {
+
+      if (err) {
+        return callback(err);
+      }
+      if (rows.length == 0) {
+        return callback('No records for query');
+      }
+      var fields = Object.keys(rows[0]);
+
+      json2csv(
+        {
+          data: rows,
+          fields: fields
+        },
+        function (err, csv) {
+          if (err) {
+            return callback(err);
+          }
+
+          if(options.removeOlderThan) {
+            rmDir(options.location, options);
+          }
+          //make the new report
+          var fileName =  options.name + "_" + moment().format("YYYY-MM-DD_HH-mm-ss") + '.csv';
+          fs.writeFile(options.location + "/" + fileName, csv, function (err) {
+            if (err) {
+              return callback(err);
+            }
+            var reportInfo = {
+              name: fileName,
+              path: options.location + '/'
+            };
+
+            callback(null, reportInfo);
+          });
+        });
+    });
+
+    connection.end();
+
+  }
+};
+
+function rmDir(dirPath, options) {
+  // TODO: rejigger this whole thing to operate async
+  try { var files = fs.readdirSync(dirPath); }
+  catch(e) { callback(e); }
+
+  if (files.length > 0) {
+    for (var i = 0; i < files.length; i++) {
+      var filePath = dirPath + '/' + files[i];
+      var fileName = files[i];
+      if (fs.statSync(filePath).isFile()) {
+        var now = moment().unix();
+        var daysAgo = now - (parseInt(options.removeOlderThan) * 86400);
+        var fileTime = moment(fs.statSync(filePath).mtime).unix();
+        if(fileName.substring(0, options.name.length) == options.name) {
+          if (fileTime  < daysAgo)
+          {
+            fs.unlinkSync(filePath);
+            console.log("deleted: " + filePath);
+          }
+          else{
+            console.log("kept: " + filePath);
+          }
+        }
+      }
+      else {
+        rmDir(filePath,options);
+      }
     }
   }
 };

--- a/albedo.js
+++ b/albedo.js
@@ -2,6 +2,7 @@ var json2csv = require('json2csv');
 var mysql = require('mysql');
 var fs = require('fs');
 var moment = require('moment');
+var _ = require('underscore');
 
 module.exports = {
    /**
@@ -35,6 +36,12 @@ module.exports = {
       }
       if (rows.length == 0) {
         return callback('No records for query');
+      }
+
+      if (options.map_funcs) {
+        _.each(options.map_funcs, function(func) {
+          rows = _.map(rows, func);
+        });
       }
       var fields = Object.keys(rows[0]);
 

--- a/albedo.js
+++ b/albedo.js
@@ -38,14 +38,19 @@ module.exports = {
         return callback('No records for query');
       }
 
-      if (options.map_funcs) {
-        _.each(options.map_funcs, function(func) {
+      // Allow calling code to pass either a function or an array of functions
+      // with which to process each row of data
+      if (_.isArray(options.process_row)) {
+        _.each(options.process_row, function(func) {
           rows = _.map(rows, func);
         });
+      } else if (_.isFunction(options.process_row)) {
+        rows = _.map(rows, options.process_row);
       }
+
       var fields = Object.keys(rows[0]);
 
-      json2csv(
+      return json2csv(
         {
           data: rows,
           fields: fields

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "albedo",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "node.js module for creating CSV reports from database queries",
   "main": "albedo.js",
   "homepage": "https://github.com/punkave/albedo",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,10 @@
     "url": "https://github.com/punkave/albedo/issues"
   },
   "dependencies": {
-    "mysql": "~2.2.0",
     "json2csv": "~2.2.1",
-    "moment": "~2.6.0"
+    "moment": "~2.6.0",
+    "mysql": "~2.2.0",
+    "underscore": "^1.7.0"
   },
   "devDependencies": {
     "mocha": "~1.20.0",


### PR DESCRIPTION
We discussed that there should be a way to do a certain amount of client-side modification of data after it comes back from MySQL. This pull request allows that to work, by passing an array of functions in options.map_funcs. Each of these functions must match the form required by _.map(...), namely they must take in a row, and return a modified row.
### Example:

Report definition:

``` javascript
    {
      filename: 'config/reports/glowcaps.sql',
      name: "Glowcaps",
      process_row: function(row) {
        var capinfo = JSON.parse(row.cap_info);
        row['cap_id'] = capinfo ? capinfo['cap_uid'] : '';
        row['cap_active'] = capinfo ? capinfo['active'] : '';
        delete row.cap_info;
        return row;
      }
    },
    {
      filename: 'plugins/wayToHealthPlugin/modules/dataReports/sql/transactions_checks.sql',
      name: "Transactions_and_Checks",
      process_row: [
        split_transaction_comment
      ]
    },
```

Map function:

``` javascript
function split_transaction_comment(row) {
  var approved_by='', approved_at='', processed_at='';
  var comments = JSON.parse(row.comments);
  if (comments) {
    comments.forEach(function(comment) {
      if (comment.note=='Approved by') {
        approved_by = comment.username;
        approved_at = comment.time;
      }
      if (comment.note=='Processed') {
        processed_at = comment.time;
      }
    });
  }
  row['approved_by'] = approved_by;
  row['approved_at'] = approved_at;
  row['processed_at'] = processed_at;
  delete row['comments'];
  return row;
}
```
